### PR TITLE
add concurrency tracking to demo

### DIFF
--- a/functions/player.mjs
+++ b/functions/player.mjs
@@ -38,7 +38,7 @@ export const handler = async (event) => {
           cache: process.env.CACHE_NAME,
           topic: 'reactions'
         }
-        ]
+      ]
     };
 
     if (accountId) {

--- a/functions/utils/helpers.mjs
+++ b/functions/utils/helpers.mjs
@@ -1,0 +1,13 @@
+export const CONCURRENT_THRESHOLD = 2;
+
+export const getAccountKey = (accountId, minutesBack = 0) => {
+  const intervalMarker = getIntervalMarker(minutesBack);
+  return `${accountId}-${intervalMarker}`;
+};
+
+const getIntervalMarker = (minutesBack) => {
+  const now = new Date();
+  now.setTime(now.getTime() - minutesBack * 60000);
+  now.setSeconds(0, 0);
+  return now.getTime();
+};

--- a/functions/webhook.mjs
+++ b/functions/webhook.mjs
@@ -1,10 +1,12 @@
-import { CacheClient, CollectionTtl } from '@gomomento/sdk';
+import { CacheClient, CacheDictionaryIncrementResponse, CollectionTtl, TopicClient } from '@gomomento/sdk';
+import { getAccountKey, CONCURRENT_THRESHOLD } from './utils/helpers.mjs';
 const cacheClient = new CacheClient({ defaultTtlSeconds: 10 });
+const topicClient = new TopicClient({});
 
 export const handler = async (event) => {
   try {
     const messageWrapper = JSON.parse(event.body);
-    const { playerId, action, bitrate, playTime, agent } = JSON.parse(messageWrapper.text);
+    const { playerId, action, bitrate, playTime, agent, accountId } = JSON.parse(messageWrapper.text);
     if (!playerId) {
       return {
         statusCode: 400,
@@ -27,6 +29,21 @@ export const handler = async (event) => {
         break;
     }
 
+    if (accountId) {
+      const key = getAccountKey(accountId);
+      const response = await cacheClient.dictionaryIncrement(process.env.CACHE_NAME, key, playerId, 1);
+      if (response.type === CacheDictionaryIncrementResponse.Success) {
+        const heartbeatCount = response.valueNumber();
+        if (heartbeatCount === 1) {
+          const lengthResponse = await cacheClient.dictionaryLength(process.env.CACHE_NAME, key);
+          const deviceCount = lengthResponse.value();
+          if (deviceCount > CONCURRENT_THRESHOLD) {
+            await topicClient.publish(process.env.CACHE_NAME, accountId, JSON.stringify({ type: 'reject', id: playerId }));
+          }
+        }
+      }
+    }
+
     return {
       statusCode: 200,
       body: JSON.stringify({ success: true }),
@@ -39,3 +56,4 @@ export const handler = async (event) => {
     };
   }
 };
+

--- a/template.yaml
+++ b/template.yaml
@@ -159,8 +159,6 @@ Resources:
             Value: main
       InstanceConfiguration:
         InstanceRoleArn: !GetAtt VideoAppRunnerRole.Arn
-        Cpu: 4 vCPU
-        Memory: 8 GB
 
 Outputs:
   VideoBaseUrl:

--- a/templates/player.hbs
+++ b/templates/player.hbs
@@ -48,9 +48,8 @@
       font-size: 30px;
       animation: floatUpAndSideways 2s linear forwards;
       pointer-events: none;
-      /* Default values */
       --rotation: 0deg;
-      --horizontalAmplitude: 20; /* Adjust as needed */
+      --horizontalAmplitude: 20;
     }
 
     @keyframes floatUpAndSideways {
@@ -101,8 +100,6 @@
         transform: translateX(0px) rotate(var(--rotation));
       }
     }
-
-
   </style>
 </head>
 
@@ -115,7 +112,7 @@
 
   <!-- Main Container -->
   <div class="container mx-auto mt-24 px-4 lg:px-0">
-
+    {{#if entitlements.isAllowed}}
     <div class="lg:flex lg:space-x-6 justify-center">
       <!-- Embed Container -->
       <div class="bg-mediumGray rounded-lg shadow-lg py-4 px-4 lg:p-6 relative lg:w-2/3 lg:mb-0 mb-4">
@@ -175,30 +172,44 @@
         </ul>
       </div>
     </div>
+    {{else}}
+    <div class="flex items-center justify-center h-screen">
+      <div class="text-center">
+        <h2 class="text-4xl font-bold text-red-600 mb-4">Too many devices</h2>
+        <p class="text-lg text-white">You currently have {{entitlements.deviceCount}} devices streaming on your account.
+          Please disconnect one ore more devices, wait a moment, and try again.</p>
+        <button id="reloadBtn" class="bg-mint text-darkGray py-2 px-4 rounded mt-4">Reload</button>
+      </div>
+    </div>
+    {{/if}}
   </div>
 
   <div id="configureStreamModal" class="fixed inset-0 hidden bg-black bg-opacity-50 flex justify-center items-center">
-      <div class="bg-darkGray p-6 rounded-lg w-1/3">
-        <div class="text-2xl font-semibold mb-4">Configure stream</div>
-        <label for="videoName" class="block text-white mb-2">Video name</label>
-        <input id="videoName" name="videoName"
-          class="w-full px-3 py-2 rounded bg-gray-600 text-white mb-4" required value="{{ stream.name }}">
-        <label for="playlistUrl" class="block text-white mb-2">Playlist url</label>
-        <input id="playlistUrl" name="playlistUrl"
-          class="w-full px-3 py-2 rounded bg-gray-600 text-white mb-4" required value="{{ stream.url }}">
-        <div class="flex justify-end">
-          <button id="closeModal" class="bg-gray-500 py-2 px-4 rounded">Close</button>
-          <button id="updateStream" class="bg-mint text-darkGray py-2 px-4 rounded ml-2">Update</button>
-        </div>
+    <div class="bg-darkGray p-6 rounded-lg w-1/3">
+      <div class="text-2xl font-semibold mb-4">Settings</div>
+      <label for="videoName" class="block text-white mb-2">Video name</label>
+      <input id="videoName" name="videoName" class="w-full px-3 py-2 rounded bg-gray-600 text-white mb-4" required value="{{ stream.name }}">
+      <label for="playlistUrl" class="block text-white mb-2">Playlist url</label>
+      <input id="playlistUrl" name="playlistUrl" class="w-full px-3 py-2 rounded bg-gray-600 text-white mb-4" required value="{{ stream.url }}">
+      <hr />
+      <label for="accountId" class="block text-white mb-2 mt-2">Account id</label>
+      <input id="accountId" name="accountId" class="w-full px-3 py-2 rounded bg-gray-600 text-white mb-4" required
+        value="{{ entitlements.accountId }}">
+      <div class="flex justify-end">
+        <button id="closeModal" class="bg-gray-500 py-2 px-4 rounded">Close</button>
+        <button id="updateStream" class="bg-mint text-darkGray py-2 px-4 rounded ml-2">Update</button>
       </div>
     </div>
+  </div>
 
+  {{#if entitlements.isAllowed}}
   <script>
     const videoPlayer = document.getElementById('videoPlayer');
     const togglePlayPauseBtn = document.getElementById('togglePlayPause');
     const toggleEventsBtn = document.getElementById('toggleEvents');
     const bufferSizeElement = document.getElementById('bufferSize');
     const segmentsDownloadedElement = document.getElementById('segmentsDownloaded');
+    let accountId = '{{ entitlements.accountId }}';
 
     const HLS_STREAM_URL = '{{ stream.url }}';
 
@@ -414,7 +425,9 @@
             action: 'heartbeat',
             bitrate,
             playTime: totalPlayTime,
-            ...userStats && { agent: userStats }
+            ...userStats && { agent: userStats },
+            ...accountId && { accountId }
+
           }),
         });
 
@@ -488,120 +501,181 @@
     }
   </script>
   <script>
-      const momentoMark = document.getElementById('momentoMark');
-      const modal = document.getElementById('configureStreamModal');
-      const closeModalBtn = document.getElementById('closeModal');
-      const updateStreamBtn = document.getElementById('updateStream');
+    const momentoMark = document.getElementById('momentoMark');
+    const modal = document.getElementById('configureStreamModal');
+    const closeModalBtn = document.getElementById('closeModal');
+    const updateStreamBtn = document.getElementById('updateStream');
 
-      momentoMark.addEventListener('click', () => {
-        modal.style.display = 'flex';
+    momentoMark.addEventListener('click', () => {
+      modal.style.display = 'flex';
+    });
+
+    closeModalBtn.addEventListener('click', () => {
+      modal.style.display = 'none';
+    });
+
+    updateStreamBtn.addEventListener('click', async () => {
+      const playlistUrl = document.getElementById('playlistUrl').value;
+      const videoName = document.getElementById('videoName').value;
+      const account = document.getElementById('accountId').value;
+
+      const queryParams = new URLSearchParams({
+        stream: playlistUrl,
+        name: videoName,
+        ...account && { accountId: account }
       });
 
-      closeModalBtn.addEventListener('click', () => {
-        modal.style.display = 'none';
-      });
+      const currentUrl = new URL(window.location.href);
+      currentUrl.search = queryParams.toString();
+      window.location.href = currentUrl.toString();
+    });
+  </script>
+  <script>
+    const emojiMap = {
+      'heart': '❤️',
+      '100': '💯',
+      'thumbsup': '👍',
+      'mindblown': '🤯'
+    };
 
-      updateStreamBtn.addEventListener('click', async () => {
-        const playlistUrl = document.getElementById('playlistUrl').value;
-        const videoName = document.getElementById('videoName').value;
+    function triggerEmojiAnimation(emojiText) {
+      const emoji = document.createElement('div');
+      const matchingEmoji = emojiMap[emojiText.toLowerCase().trim()];
+      if (!matchingEmoji) return;
 
-        const queryParams = new URLSearchParams({
-          stream: playlistUrl,
-          name: videoName
-        });
+      emoji.textContent = matchingEmoji;
+      emoji.className = 'animated-emoji';
 
-        const currentUrl = new URL(window.location.href);
-        currentUrl.search = queryParams.toString();
-        window.location.href = currentUrl.toString();
-      });
-    </script>
-    <script>
-      const emojiMap = {
-        'heart': '❤️',
-        '100': '💯',
-        'thumbsup': '👍',
-        'mindblown': '🤯'
-      };
+      // Random horizontal position within the video player
+      const videoContainer = document.getElementById('videoPlayerContainer');
+      const containerWidth = videoContainer.offsetWidth;
+      const emojiWidth = 30; // Adjust if emoji size changes
+      const randomLeft = Math.random() * (containerWidth - emojiWidth);
+      emoji.style.left = `${randomLeft}px`;
 
-      function triggerEmojiAnimation(emojiText) {
-        const emoji = document.createElement('div');
-        const matchingEmoji = emojiMap[emojiText.toLowerCase().trim()];
-        if (!matchingEmoji) return;
+      // Random rotation amount for the final rotation
+      const rotationAmount = Math.floor(Math.random() * 60) - 30; // Between -30 and 30 degrees
+      emoji.style.setProperty('--rotation', `${rotationAmount}deg`);
 
-        emoji.textContent = matchingEmoji;
-        emoji.className = 'animated-emoji';
+      // Set horizontal amplitude (maximum sideways movement)
+      const horizontalAmplitude = Math.floor(Math.random() * 20) + 10; // Between 10 and 30 pixels
+      emoji.style.setProperty('--horizontalAmplitude', horizontalAmplitude);
 
-        // Random horizontal position within the video player
-        const videoContainer = document.getElementById('videoPlayerContainer');
-        const containerWidth = videoContainer.offsetWidth;
-        const emojiWidth = 30; // Adjust if emoji size changes
-        const randomLeft = Math.random() * (containerWidth - emojiWidth);
-        emoji.style.left = `${randomLeft}px`;
+      // Append emoji to the video player container
+      videoContainer.appendChild(emoji);
 
-        // Random rotation amount for the final rotation
-        const rotationAmount = Math.floor(Math.random() * 60) - 30; // Between -30 and 30 degrees
-        emoji.style.setProperty('--rotation', `${rotationAmount}deg`);
+      setTimeout(() => { emoji.remove(); }, 2000);
+    }
 
-        // Set horizontal amplitude (maximum sideways movement)
-        const horizontalAmplitude = Math.floor(Math.random() * 20) + 10; // Between 10 and 30 pixels
-        emoji.style.setProperty('--horizontalAmplitude', horizontalAmplitude);
-
-        // Append emoji to the video player container
-        videoContainer.appendChild(emoji);
-
-        setTimeout(() => { emoji.remove(); }, 2000);
-      }
-
-      async function longPoll(signal) {
-        try {
-          const response = await fetch('{{momento.endpoint}}/reactions', {
+    async function longPoll(signal) {
+      try {
+        const response = await fetch('{{momento.endpoint}}/reactions', {
           headers: {
             'Authorization': '{{{momento.token}}}',
           }
-          });
+        });
 
-          if (response.ok) {
-            const data = await response.json();
-            if (data && data.items && data.items.length > 0) {
-              data.items.forEach(item => {
-                if (item.item && item.item.value && item.item.value.text) {
-                  triggerEmojiAnimation(item.item.value.text);
-                }
-              });
-            }
-          } else {
-            console.warn('Response not OK:', response.status);
+        if (response.ok) {
+          const data = await response.json();
+          if (data && data.items && data.items.length > 0) {
+            data.items.forEach(item => {
+              if (item.item && item.item.value && item.item.value.text) {
+                triggerEmojiAnimation(item.item.value.text);
+              }
+            });
           }
-        } catch (error) {
-          if (error.name !== 'AbortError') {
-            console.error('Long polling error:', error);
-          }
-        } finally {
-          if (!signal.aborted) {
-            setTimeout(() => longPoll(signal), 0);
-          }
+        } else {
+          console.warn('Response not OK:', response.status);
+        }
+      } catch (error) {
+        if (error.name !== 'AbortError') {
+          console.error('Long polling error:', error);
+        }
+      } finally {
+        if (!signal.aborted) {
+          setTimeout(() => longPoll(signal), 0);
         }
       }
+    }
 
-      async function sendReaction(reaction) {
-        const emoji = emojiMap[reaction];
-        if(!emoji) return;
-
-        await fetch('{{momento.endpoint}}/reactions', {
-          method: 'POST',
+    async function pollForAccountUpdates(signal) {
+      try {
+        const response = await fetch('{{momento.endpoint}}/{{entitlements.accountId}}', {
           headers: {
-            'Content-Type': 'application/json',
-            'Authorization': "{{{momento.token}}}"
-          },
-          body: reaction
-         });
+            'Authorization': '{{{momento.token}}}',
+          }
+        });
 
-        postPlayerAction(`Sent ${emoji} emoji`);
+        if (response.ok) {
+          const data = await response.json();
+          if (data && data.items && data.items.length > 0) {
+            data.items.forEach(item => {
+              if (item.item && item.item.value && item.item.value.text) {
+                const message = JSON.parse(item.item.value.text);
+                if (message.type == 'reject' && message.id == playerId) {
+                  const queryParams = new URLSearchParams({
+                    accountId: '{{entitlements.accountId}}'
+                  });
+
+                  const currentUrl = new URL(window.location.href);
+                  currentUrl.search = queryParams.toString();
+                  window.location.href = currentUrl.toString();
+                }
+              }
+            });
+          }
+        } else {
+          console.warn('Response not OK:', response.status);
+        }
+      } catch (error) {
+        if (error.name !== 'AbortError') {
+          console.error('Long polling error:', error);
+        }
+      } finally {
+        if (!signal.aborted) {
+          setTimeout(() => pollForAccountUpdates(signal), 0);
+        }
       }
+    }
 
-      const pollingController = new AbortController();
-      longPoll(pollingController.signal);
-    </script>
+    async function sendReaction(reaction) {
+      const emoji = emojiMap[reaction];
+      if (!emoji) return;
+
+      await fetch('{{momento.endpoint}}/reactions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': "{{{momento.token}}}"
+        },
+        body: reaction
+      });
+
+      postPlayerAction(`Sent ${emoji} emoji`);
+    }
+
+    const pollingController = new AbortController();
+    longPoll(pollingController.signal);
+    if(accountId){
+      pollForAccountUpdates(pollingController.signal);
+    }
+  </script>
+  {{else}}
+  <script>
+    let accountId = '{{ entitlements.accountId }}';
+    const reloadBtn = document.getElementById('reloadBtn');
+
+    reloadBtn.addEventListener('click', async () => {
+      const queryParams = new URLSearchParams({
+        ...accountId && { accountId }
+      });
+
+      const currentUrl = new URL(window.location.href);
+      currentUrl.search = queryParams.toString();
+      window.location.href = currentUrl.toString();
+    });
+  </script>
+  {{/if}}
 </body>
 
 </html>


### PR DESCRIPTION
setting max concurrency to 2

To demo this, you have to set the account id on the player to whatever you want. Once 3+ players are watching at the same time with the same account id the players will start rejecting connections.

Concurrency is rechecked every 1 minute

**CURRENT BUG**
If you go over the concurrency limit and refresh a player that's working, it will be rejected. This is because the player id is assigned and tracked client side and I haven't figured out a clever way to pass that to the server side that renders the html.